### PR TITLE
fix: correct meta description attribute

### DIFF
--- a/renderer/_default.page.server.tsx
+++ b/renderer/_default.page.server.tsx
@@ -21,7 +21,7 @@ const render = (pageContext: PageContext) => {
         <meta name="author" content="bunizao" />
         <meta property="og:title" content="bunizao" />
         <meta property="og:image" content="https://avatars.githubusercontent.com/u/102936102" />
-        <meta property="description" content="${description}" />
+        <meta name="description" content="${description}" />
         <meta property="og:description" content="${description}" />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:creator" content="@ddiu8081" />


### PR DESCRIPTION
## Summary
- ensure the HTML description meta tag uses the name attribute rather than property

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68958ca8d76c83288de89027350f6671