### PR TITLE
fix: improve mobile layout in hero

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -28,6 +28,8 @@ html {
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
   margin: 0 0.25rem;
+  display: inline-block;
+  white-space: nowrap;
 }
 
   .title {

--- a/pages/index/_components/Hero.tsx
+++ b/pages/index/_components/Hero.tsx
@@ -7,9 +7,20 @@ export default () => {
   return (
     <header class="mt-12 md:mt-18">
       <h1 class="title text-5xl font-bold">
-        <span class="block">Hello, </span><span class="block mt-2">I'm<span class="inline-flex items-baseline gap-2 whitespace-nowrap">&nbsp;<span class="highlight">Lucian</span>
-    <span class="text-slate-400/80 text-[0.4em] font-mono italic" lang="en-fonipa" aria-hidden="true">/ˈluːʃən/</span></span>
-    </span>
+        <span class="block">Hello, </span>
+        <span class="block mt-2">
+          I'm{' '}
+          <span class="inline-flex flex-wrap items-baseline gap-2 sm:flex-nowrap">
+            <span class="highlight">Lucian</span>
+            <span
+              class="text-slate-400/80 text-[0.4em] font-mono italic"
+              lang="en-fonipa"
+              aria-hidden="true"
+            >
+              /ˈluːʃən/
+            </span>
+          </span>
+        </span>
       </h1>
       <div class="mt-6">
         <div>


### PR DESCRIPTION
## Summary
- allow hero heading to wrap on small screens
- prevent keyword boxes from overlapping or breaking across lines

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68973bf71c94832892b65326b8af6d17