### PR TITLE
fix: improve mobile layout in hero

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -25,9 +25,10 @@ html {
 
 .keyword-box {
   border: 1px solid #4b5563;
-  padding: 0.25rem 0.5rem;
+  padding: 0.125rem 0.375rem;
   border-radius: 0.375rem;
-  margin: 0 0.25rem;
+  display: inline-block;
+  white-space: nowrap;
 }
 
   .title {

--- a/pages/index/_components/Hero.tsx
+++ b/pages/index/_components/Hero.tsx
@@ -7,19 +7,44 @@ export default () => {
   return (
     <header class="mt-12 md:mt-18">
       <h1 class="title text-5xl font-bold">
-        <span class="block">Hello, </span><span class="block mt-2">I'm<span class="inline-flex items-baseline gap-2 whitespace-nowrap">&nbsp;<span class="highlight">Lucian</span>
-    <span class="text-slate-400/80 text-[0.4em] font-mono italic" lang="en-fonipa" aria-hidden="true">/ˈluːʃən/</span></span>
-    </span>
+        <span class="block">Hello, </span>
+        <span class="block mt-2">
+          I'm{' '}
+          <span class="inline-flex flex-wrap items-baseline gap-2 sm:flex-nowrap">
+            <span class="highlight">Lucian</span>
+            <span
+              class="text-slate-400/80 text-[0.4em] font-mono italic"
+              lang="en-fonipa"
+              aria-hidden="true"
+            >
+              /ˈluːʃən/
+            </span>
+          </span>
+        </span>
       </h1>
       <div class="mt-6">
         <div>
             <span>🎓 <span class="font-mono">DataScience</span> Student @ <span class="font-monash font-bold">MONASH</span> <span class="font-mono">'28</span>&nbsp;&nbsp;/&nbsp;&nbsp;♎️ <span class="font-monash font-bold">Libra</span> in <span class="font-mono">'06</span></span>&nbsp;&nbsp;/&nbsp;&nbsp;🧚 <span class="font-mono">INFP-T</span>
         </div>
         <div class="mt-2">
-          <span>🌐 Exploring the depths of the Internet through <span class="font-mono keyword-box">🌍 BGP</span>, <span class="font-mono keyword-box">💻 Coding</span>, and <span class="font-mono keyword-box">🔗 Web3</span>.</span>
+          <span>
+            🌐 Exploring the depths of the Internet through{' '}
+            <span class="inline-flex flex-wrap items-center gap-2 after:content-['.'] after:ml-1">
+              <span class="font-mono text-sm keyword-box">🌍 BGP</span>
+              <span class="font-mono text-sm keyword-box">💻 Coding</span>
+              <span class="font-mono text-sm keyword-box">🔗 Web3</span>
+            </span>
+          </span>
         </div>
         <div class="mt-2">
-          <span>✨ Also a <span class="font-mono keyword-box">🎬 Cinephile</span>, <span class="font-mono keyword-box">✍️ Blogger</span>, and <span class="font-mono keyword-box">📖 Perpetual learner</span>.</span>
+          <span>
+            ✨ Also a{' '}
+            <span class="inline-flex flex-wrap items-center gap-2 after:content-['.'] after:ml-1">
+              <span class="font-mono text-sm keyword-box">🎬 Cinephile</span>
+              <span class="font-mono text-sm keyword-box">✍️ Blogger</span>
+              <span class="font-mono text-sm keyword-box">📖 Perpetual learner</span>
+            </span>
+          </span>
         </div>
       </div>
       <Socials />


### PR DESCRIPTION
## Summary
- allow hero heading to wrap on small screens
- prevent keyword boxes from overlapping or breaking across lines
- equalize spacing between keyword boxes
- keep keyword punctuation inline and balance box text size

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68973bf71c94832892b65326b8af6d17