### PR TITLE
style: use flex gaps for keywords

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -25,9 +25,8 @@ html {
 
 .keyword-box {
   border: 1px solid #4b5563;
-  padding: 0.25rem 0.5rem;
+  padding: 0.125rem 0.5rem;
   border-radius: 0.375rem;
-  margin: 0 0.25rem;
 }
 
   .title {

--- a/pages/index/_components/Hero.tsx
+++ b/pages/index/_components/Hero.tsx
@@ -19,7 +19,13 @@ export default () => {
           <span>🌐 Exploring the depths of the Internet through <span class="font-mono keyword-box">🌍 BGP</span>, <span class="font-mono keyword-box">💻 Coding</span>, and <span class="font-mono keyword-box">🔗 Web3</span>.</span>
         </div>
         <div class="mt-2">
-          <span>✨ Also a <span class="font-mono keyword-box">🎬 Cinephile</span>, <span class="font-mono keyword-box">✍️ Blogger</span>, and <span class="font-mono keyword-box">📖 Perpetual learner</span>.</span>
+          <span>✨ Also a </span>
+          <span class="inline-flex flex-wrap items-center gap-2">
+            <span class="font-mono keyword-box">🎬 Cinephile</span>
+            <span class="font-mono keyword-box">✍️ Blogger</span>
+            <span>and</span>
+            <span class="font-mono keyword-box">📖 Perpetual learner</span>
+          </span>.
         </div>
       </div>
       <Socials />


### PR DESCRIPTION
## Summary
- wrap hero keyword tags and conjunction in a flex container with gaps
- shrink keyword-box vertical padding and remove margin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897435c022083289709941483974832